### PR TITLE
Add Django helpdesk integration

### DIFF
--- a/apps/aklub/tests/test_admin.py
+++ b/apps/aklub/tests/test_admin.py
@@ -40,6 +40,7 @@ from ..models import (
 
 class AdminSmokeTest(tests.AdminSiteSmokeTest):
     fixtures = ['conditions', 'users']
+    exclude_apps = ['helpdesk']
 
     def post_request(self, post_data={}, params=None):
         request = self.factory.post('/', data=post_data)

--- a/project/settings/base.py
+++ b/project/settings/base.py
@@ -146,6 +146,7 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.messages',
     'django.contrib.sessions',
+    'django.contrib.sites',
     'django.contrib.staticfiles',
     'django.contrib.humanize',
     'stdimage',
@@ -155,6 +156,7 @@ INSTALLED_APPS = (
     'tinymce',
     'chart_tools',
     'massadmin',
+    'markdown_deux',
     'post_office',
     'import_export',
     'corsheaders',
@@ -167,7 +169,8 @@ INSTALLED_APPS = (
     'django_nvd3',
     'adminfilters',
     'advanced_filters',
-    'aklub'
+    'helpdesk',
+    'aklub',
 )
 
 BOWER_INSTALLED_APPS = (
@@ -259,6 +262,32 @@ AUTH_USER_MODEL = "aklub.UserProfile"
 AUTHENTICATION_BACKENDS = [
     'django.contrib.auth.backends.ModelBackend',
 ]
+
+HELPDESK_DEFAULT_SETTINGS = {
+    'use_email_as_submitter': True,
+    'email_on_ticket_assign': True,
+    'email_on_ticket_change': True,
+    'login_view_ticketlist': True,
+    'email_on_ticket_apichange': True,
+    'preset_replies': True,
+    'tickets_per_page': 25,
+}
+
+# Should the public web portal be enabled?
+HELPDESK_VIEW_A_TICKET_PUBLIC = False
+HELPDESK_SUBMIT_A_TICKET_PUBLIC = True
+
+HELPDESK_PUBLIC_TICKET_PRIORITY = 3
+HELPDESK_PUBLIC_TICKET_DUE_DATE = ''
+
+# Should the Knowledgebase be enabled?
+HELPDESK_KB_ENABLED = True
+
+# Instead of showing the public web portal first,
+# we can instead redirect users straight to the login page.
+HELPDESK_REDIRECT_TO_LOGIN_BY_DEFAULT = False
+LOGIN_URL = '/login/'
+LOGIN_REDIRECT_URL = '/login/'
 
 CSRF_COOKIE_SECURE = True
 SECURE_BROWSER_XSS_FILTER = True

--- a/project/urls.py
+++ b/project/urls.py
@@ -10,6 +10,7 @@ from django.views.i18n import JavaScriptCatalog
 admin.autodiscover()
 
 urlpatterns = [
+    url(r'^desk/', include("helpdesk.urls")),
     url(r'^admin/passreset/$', auth_views.password_reset, name='password_reset'),
     url(r'^admin/passresetdone/$', auth_views.password_reset_done, name='password_reset_done'),
     url(

--- a/requirements.freeze.txt
+++ b/requirements.freeze.txt
@@ -28,6 +28,7 @@ django-sesame==1.4
 django-stdimage==3.2.0
 django-tinymce==2.7.0
 django-wysiwyg==0.8.0
+-e git+https://github.com/django-helpdesk/django-helpdesk.git@a3bc6ed46bb1a00ce4664dfeac155e4b11b842a8#egg=django-helpdesk
 djcacheutils==3.0.0
 et-xmlfile==1.0.1
 feedparser==5.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ django-daterange-filter
 django-cors-headers
 django-related-admin
 django-denorm
+django-helpdesk
 gunicorn
 pypdf2  # for pdf result testing
 django-betterforms


### PR DESCRIPTION
It looks really promising in terms of potential integration. https://github.com/django-helpdesk/django-helpdesk/pull/631 was really easy to implement.

Unfortunately, we'd have to solve https://github.com/django-helpdesk/django-helpdesk/issues/629 before I'd feel comfortable using it in production.