### PR TITLE
set missing DATABASE_HOST global env, app doesn't connect to the db

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -4,6 +4,7 @@ DJANGO_SETTINGS_MODULE=project.settings.dev
 DATABASE_NAME=klub
 DATABASE_USER=klub
 DATABASE_PASSWORD=foobar
+DATABASE_HOST=postgres
 AKLUB_ADMINS=John Doe, john.doe@example.com
 AKLUB_SERVER_EMAIL=server@example.com
 AKLUB_DEFAULT_FROM_EMAIL=Server <server@example.com>


### PR DESCRIPTION
Set missing `DATABASE_HOST=postgres` global env in the .env-sample file (app doesn't connect to the postgresql db)