### PR TITLE
Fix the wrong django-admin compilemessages -l argument parameter in README file (docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Instalace (Docker compose)
     # su test
     $ pipenv install --dev --python python3
     $ pipenv shell
-    $ cd apps/aklub && django-admin.py compilemessages -l "cs\_CZ"
+    $ cd apps/aklub && django-admin.py compilemessages -l cs_CZ
     $ django-admin.py migrate
     $ django-admin.py createsuperuser
 


### PR DESCRIPTION
`django-admin compilemessages -l "cs\_CZ"` command doesn't compile messages (according installation instruction for the docker compose in the README file). The command return quickly with no output to the stdout. No .mo file be create. 12 tests (tests related with translation) fail.