### PR TITLE
fix: set missing 'DATABASE_HOST' global env var

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,6 +1,7 @@
 SECRET_KEY=change_me
 DJANGO_SETTINGS_MODULE=project.settings.dev
 # For production use project.settings.base
+DATABASE_HOST=postgres
 DATABASE_NAME=klub
 DATABASE_USER=klub
 DATABASE_PASSWORD=foobar


### PR DESCRIPTION
Set missing `DATABASE_HOST` global env var.

**To Reproduce:**

1. `cp .env-sample .env`
2. Fresh app build `docker-compose build` according [README](https://github.com/auto-mat/klub/blob/master/README.md#instalace-docker-compose)
3. Start django dev server `python manage.py runserver 0.0.0.0:8000`

**Error message:**

```
Traceback (most recent call last):
  File "/home/test/.local/share/virtualenvs/klub-v-nnivlwsY/lib/python3.6/site-packages/django/db/backends/base/base.py", line 217, in ensure_connection
    self.connect()
  File "/home/test/.local/share/virtualenvs/klub-v-nnivlwsY/lib/python3.6/site-packages/django/db/backends/base/base.py", line 195, in connect
    self.connection = self.get_new_connection(conn_params)
  File "/home/test/.local/share/virtualenvs/klub-v-nnivlwsY/lib/python3.6/site-packages/django/db/backends/postgresql/base.py", line 178, in get_new_connection
    connection = Database.connect(**conn_params)
  File "/home/test/.local/share/virtualenvs/klub-v-nnivlwsY/lib/python3.6/site-packages/psycopg2/__init__.py", line 127, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
psycopg2.OperationalError: could not connect to server: No such file or directory
	Is the server running locally and accepting
	connections on Unix domain socket "/var/run/postgresql/.s.PGSQL.5432"?
```