### PR TITLE
fix: manual instruction to create a Site object corresponding to the domain, before first start app

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Instalace (Docker compose)
     $ python3 manage.py compilemessages -l "cs\_CZ"
     $ django-admin.py migrate
     $ django-admin.py createsuperuser
+    # Set django Site object domain name
+    $ python manage.py shell
+    # 'localhost' if app will run on localhost
+    >>> from django.contrib.sites.models import Site
+    >>> Site.objects.create(name='localhost', domain='localhost')
+    >>> exit()
 
 Spuštění
 ============


### PR DESCRIPTION
Set manual instruction to create a Site object corresponding to the domain, before first start app.

**To Reproduce:**

1. `cp .env-sample .env`
2. Fresh app build `docker-compose build` according [README](https://github.com/auto-mat/klub/blob/master/README.md#instalace-docker-compose)
3. Start django dev server `python manage.py runserver 0.0.0.0:8000`
4. Launch web browser, go to address localhost:8000/ 

**Error message:**

```
Exception Value: Site matching query does not exist.
```