### PR TITLE
Pipfile/Pipfile.lock: reinstall custom 'django-advanced-filters' app

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -92,6 +92,7 @@ faker = "*"
 django-computedfields = "==0.0.23"
 django-oauth-toolkit = "*"
 unidecode = "*"
+django-advanced-filters = {editable = true,git = "https://github.com/tmszi/django-advanced-filters",ref = "extended-af"}
 
 [dev-packages]
 coverage = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "aeaa2304017572e15c157efe6763849838b077be7dd7ffee283bd92aff571700"
+            "sha256": "53578918397009dd5c40a679a0756e314de04a76e4b82aaa4d8ce8c676476e5e"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -132,10 +132,10 @@
         },
         "django": {
             "hashes": [
-                "sha256:558cb27930defd9a6042133258caf797b2d1dee233959f537e3dc475cb49bd7c",
-                "sha256:cf5370a4d7765a9dd6d42a7b96b53c74f9446cd38209211304b210fe0404b861"
+                "sha256:0eaca08f236bf502a9773e53623f766cc3ceee6453cc41e6de1c8b80f07d2364",
+                "sha256:c9c994f5e0a032cbd45089798b52e4080f4dea7241c58e3e0636c54146480bb4"
             ],
-            "version": "==2.2.17"
+            "version": "==2.2.18"
         },
         "django-admin-charts": {
             "hashes": [
@@ -189,8 +189,8 @@
         },
         "django-advanced-filters": {
             "editable": true,
-            "git": "https://github.com/tmszi/django-advanced-filters.git",
-            "ref": "396f445f730cdc1a443b861312f2d8479f888903"
+            "git": "https://github.com/tmszi/django-advanced-filters",
+            "ref": "b1140568f1035a4524761a18259d76a70701d861"
         },
         "django-appconf": {
             "hashes": [
@@ -1470,7 +1470,8 @@
     "develop": {
         "asgiref": {
             "hashes": [
-                "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17"
+                "sha256:5ee950735509d04eb673bd7f7120f8fa1c9e2df495394992c73234d526907e17",
+                "sha256:7162a3cb30ab0609f1a4c95938fd73e8604f63bdba516a7f7d64b83ff09478f0"
             ],
             "version": "==3.3.1"
         },
@@ -1567,10 +1568,10 @@
         },
         "django": {
             "hashes": [
-                "sha256:558cb27930defd9a6042133258caf797b2d1dee233959f537e3dc475cb49bd7c",
-                "sha256:cf5370a4d7765a9dd6d42a7b96b53c74f9446cd38209211304b210fe0404b861"
+                "sha256:0eaca08f236bf502a9773e53623f766cc3ceee6453cc41e6de1c8b80f07d2364",
+                "sha256:c9c994f5e0a032cbd45089798b52e4080f4dea7241c58e3e0636c54146480bb4"
             ],
-            "version": "==2.2.17"
+            "version": "==2.2.18"
         },
         "django-admin-smoke-tests-2": {
             "editable": true,
@@ -1693,7 +1694,8 @@
         },
         "ipython-genutils": {
             "hashes": [
-                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8"
+                "sha256:72dd37233799e619666c9f639a9da83c34013a73e8bbc79a7a6348d93c61fab8",
+                "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"
             ],
             "version": "==0.2.0"
         },
@@ -1728,7 +1730,8 @@
         },
         "parso": {
             "hashes": [
-                "sha256:15b00182f472319383252c18d5913b69269590616c947747bc50bf4ac768f410"
+                "sha256:15b00182f472319383252c18d5913b69269590616c947747bc50bf4ac768f410",
+                "sha256:8519430ad07087d4c997fda3a7918f7cfa27cb58972a8c89c2a0295a1c940e9e"
             ],
             "version": "==0.8.1"
         },
@@ -1763,7 +1766,8 @@
         },
         "ptyprocess": {
             "hashes": [
-                "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"
+                "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35",
+                "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"
             ],
             "version": "==0.7.0"
         },
@@ -1880,7 +1884,8 @@
         },
         "wcwidth": {
             "hashes": [
-                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"
+                "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784",
+                "sha256:c4d647b99872929fdb7bdcaa4fbe7f01413ed3d98077df798530e5b04f116c83"
             ],
             "version": "==0.2.5"
         },


### PR DESCRIPTION
Reinstall custom 'django-advanced-filters' app (missing entry  in the Pipfile) + update Pipfile.lock file.