### PR TITLE
Save event_type to events

### DIFF
--- a/apps/api/serializers.py
+++ b/apps/api/serializers.py
@@ -446,6 +446,7 @@ class LocationSerializer(serializers.ModelSerializer):
 class EventSerializer(serializers.ModelSerializer):
     location = LocationSerializer(read_only=True)
     event_type = EventTypeSerializer(read_only=True)
+    event_type_id = serializers.PrimaryKeyRelatedField(source="event_type", queryset=EventType.objects.all())
     administrative_unit_name = serializers.SerializerMethodField()
     administrative_unit_web_url = serializers.SerializerMethodField()
 
@@ -465,6 +466,7 @@ class EventSerializer(serializers.ModelSerializer):
             "age_to",
             "start_date",
             "event_type",
+            "event_type_id",
             "responsible_person",
             "participation_fee",
             "entry_form_url",


### PR DESCRIPTION
Make it possible to save event_type to events. Currently it doesn't seem to be saveable. This is also an issue with possible solution.

https://stackoverflow.com/a/53936521

Created additional writable field event_type_id, which accepts id of a desired event_type.

This will probably break some tests. I haven't run tests successfully.

