### PR TITLE
[Bug] Fix set SECRET_KEY global ENV variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,6 @@ RUN mkdir -p /var/log/django/
 copy requirements.txt requirements.txt
 RUN su test ; pip3 install --default-timeout=100 -r requirements.txt
 copy . .
-RUN SECRET_KEY="fake_key" python3 manage.py bower install
-RUN SECRET_KEY="fake_key" python3 manage.py compilemessages --ignore=third-party/*
-RUN SECRET_KEY="fake_key" python3 manage.py collectstatic --noinput
+RUN set SECRET_KEY="fake_key" python3 manage.py bower install
+RUN set SECRET_KEY="fake_key" python3 manage.py compilemessages --ignore=third-party/*
+RUN set SECRET_KEY="fake_key" python3 manage.py collectstatic --noinput


### PR DESCRIPTION
**Describe the bug**
Build Docker images fails.

**To Reproduce**
Steps to reproduce the behavior:

1. Clone Git repository `git clone https://github.com/auto-mat/klub.git`
2. Follow installation doc https://github.com/auto-mat/klub#instalace-docker-compose
3. Run `docker-compose up` command
4. See error

```
Step 15/17 : RUN SECRET_KEY="fake_key" python3 manage.py bower install
 ---> Running in 0e3ee00a6f71
Traceback (most recent call last):
  File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 224, in fetch_command
    app_name = commands[subcommand]
KeyError: 'bower'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/aplikace/manage.py", line 26, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 401, in execute_from_command_line
    utility.execute()
  File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 395, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/lib/python3.9/site-packages/django/core/management/__init__.py", line 231, in fetch_command
    settings.INSTALLED_APPS
  File "/usr/local/lib/python3.9/site-packages/django/conf/__init__.py", line 82, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python3.9/site-packages/django/conf/__init__.py", line 69, in _setup
    self._wrapped = Settings(settings_module)
  File "/usr/local/lib/python3.9/site-packages/django/conf/__init__.py", line 170, in __init__
    mod = importlib.import_module(self.SETTINGS_MODULE)
  File "/usr/local/lib/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/home/aplikace/project/settings/__init__.py", line 21, in <module>
    from .base import *  # noqa
  File "/home/aplikace/project/settings/base.py", line 593, in <module>
    print(api_settings.DEFAULT_AUTHENTICATION_CLASSES)
  File "/usr/local/lib/python3.9/site-packages/rest_framework/settings.py", line 218, in __getattr__
    val = self.user_settings[attr]
  File "/usr/local/lib/python3.9/site-packages/rest_framework/settings.py", line 209, in user_settings
    self._user_settings = getattr(settings, 'REST_FRAMEWORK', {})
  File "/usr/local/lib/python3.9/site-packages/django/conf/__init__.py", line 82, in __getattr__
    self._setup(name)
  File "/usr/local/lib/python3.9/site-packages/django/conf/__init__.py", line 69, in _setup
    self._wrapped = Settings(settings_module)
  File "/usr/local/lib/python3.9/site-packages/django/conf/__init__.py", line 189, in __init__
    raise ImproperlyConfigured("The SECRET_KEY setting must not be empty.")
django.core.exceptions.ImproperlyConfigured: The SECRET_KEY setting must not be empty.
```

**Expected behavior**
Build Docker images should work.
